### PR TITLE
Add examples for the new Policies APIs in 11.3.0

### DIFF
--- a/8_policies/crud_policy/build.gradle
+++ b/8_policies/crud_policy/build.gradle
@@ -1,0 +1,16 @@
+apply plugin : "application"
+
+mainClassName = "CRUDPolicy"
+
+sourceSets.main.java.srcDirs = ['src']
+
+group = 'io.github.strongdm'
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation "io.github.strongdm:strongdm-sdk-java:11.3.0"
+    implementation "org.json:json:20190722"
+}

--- a/8_policies/crud_policy/src/CRUDPolicy.java
+++ b/8_policies/crud_policy/src/CRUDPolicy.java
@@ -1,0 +1,82 @@
+// Copyright 2024 StrongDM Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import com.strongdm.api.*;
+
+public class CRUDPolicy {
+    public static void main(String[] args) {
+        // Load the SDM API keys from the environment.
+        // If these values are not set in your environment,
+        // please follow the documentation here:
+        // https://www.strongdm.com/docs/api/api-keys/
+        var apiAccessKey = System.getenv("SDM_API_ACCESS_KEY");
+        var apiSecretKey = System.getenv("SDM_API_SECRET_KEY");
+        if (apiAccessKey == null || apiSecretKey == null) {
+            System.out.println("SDM_API_ACCESS_KEY and SDM_API_SECRET_KEY must be provided");
+            return;
+        }
+
+
+        try {
+            // Create the SDM Client
+            var opts = new ClientOptions();
+            var client = new Client(apiAccessKey, apiSecretKey, opts);
+
+            var policy = new Policy();
+            policy.setName("forbid-everything");
+            policy.setDescription("Forbid everything");
+            policy.setPolicy("forbid ( principal, action, resource );");
+
+            var createResp = client.policies().create(policy);
+            System.out.println("Successfully created a policy to forbid all actions.");
+            System.out.printf("\tID: %s\n", createResp.getPolicy().getId());
+            System.out.printf("\tName: %s\n", createResp.getPolicy().getName());
+
+            // Note: The `policy` we from `createResp` can also be used to
+            // make an update. However, we'll load it from the API to
+            // demonstrate `get`.
+
+            var getResp = client.policies().get(createResp.getPolicy().getId());
+
+            var updatePolicy = getResp.getPolicy();
+            updatePolicy.setName("forbid-one-thing");
+            updatePolicy.setDescription("forbid connecting to the bad resource");
+            updatePolicy.setPolicy("forbid ( principal, action == StrongDM::Action::\"connect\", resource == StrongDM::Resource::\"rs-123d456789\");");
+
+            // Execute the update.
+            var updateResp = client.policies().update(updatePolicy);
+            System.out.println("Successfully updated policy.");
+            System.out.printf("\tID: %s\n", updateResp.getPolicy().getId());
+            System.out.printf("\tName: %s\n", updateResp.getPolicy().getName());
+            System.out.printf("\tDescription: %s\n", updateResp.getPolicy().getDescription());
+            System.out.printf("\tPolicy: %s\n", updateResp.getPolicy().getPolicy());
+
+            // We'll now delete the policy
+            client.policies().delete(createResp.getPolicy().getId());
+
+            // And then try to retrieve our newly deleted policy, expecting
+            // a NotFoundException...
+            try {
+                client.policies().get(createResp.getPolicy().getId());
+            } catch (NotFoundException e) {
+                // We're expecting this.
+            }
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+    }
+}

--- a/8_policies/find_policy/build.gradle
+++ b/8_policies/find_policy/build.gradle
@@ -1,0 +1,16 @@
+apply plugin : "application"
+
+mainClassName = "FindPolicy"
+
+sourceSets.main.java.srcDirs = ['src']
+
+group = 'io.github.strongdm'
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation "io.github.strongdm:strongdm-sdk-java:11.3.0"
+    implementation "org.json:json:20190722"
+}

--- a/8_policies/find_policy/src/FindPolicy.java
+++ b/8_policies/find_policy/src/FindPolicy.java
@@ -1,0 +1,105 @@
+// Copyright 2024 StrongDM Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.List;
+import com.strongdm.api.*;
+
+
+public class FindPolicy {
+    private static Policy newPolicy(String name, String description, String policy) {
+        var p = new Policy();
+        p.setName(name);
+        p.setDescription(description);
+        p.setPolicy(policy);
+        return p;
+    }
+
+    public static List<Policy> EXAMPLE_POLICIES = new ArrayList<>(Arrays.asList(
+    newPolicy(
+        "default-permit-policy",
+        "a default permit policy",
+        "permit (principal, action, resource);"
+    ),
+    newPolicy(
+        "permit-sql-select-policy",
+        "a permit sql select policy",
+        "permit (principal, action == SQL::Action::\"select\", resource == Postgres::Database::\"*\");"
+    ),
+    newPolicy(
+        "default-forbid-policy",
+        "a default forbid policy",
+        "forbid (principal, action, resource);"
+    ),
+    newPolicy(
+        "forbid-connect-policy",
+        "a forbid connect policy",
+        "forbid (principal, action == StrongDM::Action::\"connect\", resource);"
+    ),
+    newPolicy(
+        "forbid-sql-delete-policy",
+        "a forbid delete policy on all resources",
+        "forbid (principal, action == SQL::Action::\"delete\", resource == Postgres::Database::\"*\");"
+      )
+));
+
+    public static void main(String[] args) {
+        // Load the SDM API keys from the environment.
+        // If these values are not set in your environment,
+        // please follow the documentation here:
+        // https://www.strongdm.com/docs/api/api-keys/
+        var apiAccessKey = System.getenv("SDM_API_ACCESS_KEY");
+        var apiSecretKey = System.getenv("SDM_API_SECRET_KEY");
+        if (apiAccessKey == null || apiSecretKey == null) {
+            System.out.println("SDM_API_ACCESS_KEY and SDM_API_SECRET_KEY must be provided");
+            return;
+        }
+
+        var policiesToCleanup = new ArrayList<Policy>();
+
+
+        try {
+            // Create the SDM Client
+            var opts = new ClientOptions();
+            var client = new Client(apiAccessKey, apiSecretKey, opts);
+
+            // Create our example policies
+            for (Policy p : EXAMPLE_POLICIES) {
+                var resp = client.policies().create(p);
+                policiesToCleanup.add(resp.getPolicy());
+            }
+
+            System.out.println("Finding all Policies with a name containing 'sql'");
+            var policies = client.policies().list("name:*sql*");
+            for (Policy p : policies) {
+                System.out.printf("\tID: %s\tName:%s\n", p.getId(), p.getName());
+            }
+
+            System.out.println("Finding all Policies that forbid");
+            policies = client.policies().list("policy:forbid*");
+            for (Policy p : policies) {
+                System.out.printf("\tID: %s\tName:%s\n", p.getId(), p.getName());
+            }
+
+            // Try to cleanup the policies we created.
+            for (Policy p : policiesToCleanup) {
+                client.policies().delete(p.getId());
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}


### PR DESCRIPTION
This adds two examples that make use of the Policies API in SDKs 11.3.0 and later. These are ported from the Policies examples in [strongdm-sdk-go-examples](https://github.com/strongdm/strongdm-sdk-go-examples/tree/master/8_policies)

The first, crud_policy, creates, updates, and then deletes a Policy. It then verifies that the Policy was deleted by making a Get request and ensuring that it was not found.

In the second example, find_policy, we creates examples Policies and then perform 2 filtered searches on them.

These were tested manually.